### PR TITLE
Make redo/undo buttons insensitive when can't redo/undo

### DIFF
--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.38.2 -->
 <interface>
-  <requires lib="gtk+" version="3.24"/>
-  <requires lib="gtksourceview" version="4.0"/>
-  <requires lib="libhandy" version="0.0"/>
+  <requires lib="gtk+" version="3.24" />
+  <requires lib="gtksourceview" version="4.0" />
+  <requires lib="libhandy" version="0.0" />
   <object class="GtkPopover" id="menu_popover">
     <property name="can-focus">False</property>
     <child>
@@ -18,7 +18,7 @@
             <property name="receives-default">True</property>
             <property name="action-name">win.show-keybindings</property>
             <property name="text" translatable="yes" context="main menu">Keyboard shortcuts</property>
-            <accelerator key="question" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+            <accelerator key="question" signal="activate" modifiers="GDK_CONTROL_MASK" />
           </object>
           <packing>
             <property name="expand">False</property>
@@ -85,7 +85,7 @@
                     <property name="editable">False</property>
                     <property name="primary-icon-name">applications-utilities-symbolic</property>
                     <property name="placeholder-text" translatable="yes" context="tool entry">Select tool...</property>
-                    <accelerator key="Return" signal="grab-focus" modifiers="GDK_MOD1_MASK"/>
+                    <accelerator key="Return" signal="grab-focus" modifiers="GDK_MOD1_MASK" />
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -107,9 +107,9 @@
                         <property name="icon-name">object-select-symbolic</property>
                       </object>
                     </child>
-                    <accelerator key="a" signal="clicked" modifiers="GDK_MOD1_MASK"/>
+                    <accelerator key="a" signal="clicked" modifiers="GDK_MOD1_MASK" />
                     <style>
-                      <class name="suggested-action"/>
+                      <class name="suggested-action" />
                     </style>
                   </object>
                   <packing>
@@ -119,7 +119,7 @@
                   </packing>
                 </child>
                 <style>
-                  <class name="linked"/>
+                  <class name="linked" />
                 </style>
               </object>
               <packing>
@@ -140,7 +140,7 @@
                     <property name="icon-name">open-menu-symbolic</property>
                   </object>
                 </child>
-                <accelerator key="F10" signal="activate"/>
+                <accelerator key="F10" signal="activate" />
               </object>
               <packing>
                 <property name="pack-type">end</property>
@@ -159,7 +159,7 @@
                     <property name="icon-name">edit-copy-symbolic</property>
                   </object>
                 </child>
-                <accelerator key="c" signal="clicked" modifiers="GDK_MOD1_MASK"/>
+                <accelerator key="c" signal="clicked" modifiers="GDK_MOD1_MASK" />
               </object>
               <packing>
                 <property name="pack-type">end</property>
@@ -170,6 +170,7 @@
               <object class="GtkButton" id="undo_button">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
+                <property name="sensitive">False</property>
                 <property name="receives-default">True</property>
                 <property name="action-name">win.undo</property>
                 <child>
@@ -179,7 +180,7 @@
                     <property name="icon-name">edit-undo-symbolic</property>
                   </object>
                 </child>
-                <accelerator key="z" signal="clicked" modifiers="GDK_CONTROL_MASK"/>
+                <accelerator key="z" signal="clicked" modifiers="GDK_CONTROL_MASK" />
               </object>
               <packing>
                 <property name="position">2</property>
@@ -189,6 +190,7 @@
               <object class="GtkButton" id="redo_button">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
+                <property name="sensitive">False</property>
                 <property name="receives-default">True</property>
                 <property name="action-name">win.redo</property>
                 <child>
@@ -198,7 +200,7 @@
                     <property name="icon-name">edit-redo-symbolic</property>
                   </object>
                 </child>
-                <accelerator key="z" signal="clicked" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK"/>
+                <accelerator key="z" signal="clicked" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK" />
               </object>
               <packing>
                 <property name="position">3</property>
@@ -293,5 +295,5 @@
       </object>
     </child>
   </object>
-  <object class="GtkSourceBuffer" id="text_buffer"/>
+  <object class="GtkSourceBuffer" id="text_buffer" />
 </interface>

--- a/src/window.vala
+++ b/src/window.vala
@@ -33,6 +33,10 @@ namespace Textpieces {
         private Gtk.Button apply_button;
         [GtkChild]
         private Gtk.Popover copied_popover;
+        [GtkChild]
+        private Gtk.Button undo_button;
+        [GtkChild]
+        private Gtk.Button redo_button;
 
         Tool? current_tool = null;
 
@@ -158,6 +162,11 @@ namespace Textpieces {
 
         void check_whether_can_do_actions () {
             apply_button.set_sensitive (text_buffer.text != "" && current_tool != null);
+            Idle.add (() => {
+                undo_button.set_sensitive (text_buffer.can_undo);
+                redo_button.set_sensitive (text_buffer.can_redo);
+                return false;
+            });
         }
 
         void action_undo () {


### PR DESCRIPTION
I've found the way to make undo/redo buttons insensitive when their actions can't be applied. It can't be done on text changed because at this time SourceBuffer.can_undo/can_redo is always false, but it can be done just after text changed via Idle.add.

Also VSCode formatted window.ui file lol