### PR TITLE
Fix some styling issues

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -28,8 +28,8 @@ checkbutton.theme-selector radio {
   background: none;
   box-shadow: none;
   padding: 15px;
-  min-height: 24px;
-  min-width: 24px;
+  min-height: 18px;
+  min-width: 18px;
   border-width: 3px;
   border-style: solid;
   border-color: transparent;

--- a/resources/style.css
+++ b/resources/style.css
@@ -1,8 +1,7 @@
 /* Custom tool row */
 
-list.nested row {
+row.form-row:not(:last-child) {
   border: none;
-  background-color: @theme_base_color;
 }
 
 button.large {

--- a/resources/ui/CustomToolRow.ui
+++ b/resources/ui/CustomToolRow.ui
@@ -12,6 +12,9 @@
         <child>
           <object class="GtkEntry" id="name_entry" />
         </child>
+        <style>
+          <class name="form-row"/>
+        </style>
       </object>
     </child>
     <child>
@@ -21,6 +24,9 @@
         <child>
           <object class="GtkEntry" id="description_entry" />
         </child>
+        <style>
+          <class name="form-row"/>
+        </style>
       </object>
     </child>
     <child>
@@ -67,6 +73,9 @@
             </child>
           </object>
         </child>
+        <style>
+          <class name="form-row"/>
+        </style>
       </object>
     </child>
   </template>

--- a/resources/ui/Window.ui
+++ b/resources/ui/Window.ui
@@ -320,6 +320,8 @@
         <!-- Dummy target used because GTK checks equality between target type and action parameter -->
         <attribute name="target">'dark'</attribute>
       </item>
+    </section>
+    <section>
       <item>
         <attribute name="label" translatable="yes">Preferences</attribute>
         <attribute name="action">win.preferences</attribute>


### PR DESCRIPTION
- Rework tool setting row CSS adapting to new Adwaita changes
- Make theme switcher smaller since it's too huge for new Adwaita
- Add separator between the main menu and the theme switcher