### PR TITLE
Add keywords to .desktop file

### DIFF
--- a/data/com.github.liferooter.textpieces.desktop.in
+++ b/data/com.github.liferooter.textpieces.desktop.in
@@ -12,6 +12,9 @@ Categories=Utility;TextTools;GTK;GNOME;
 StartupNotify=true
 Actions=new-window;
 
+# Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+Keywords=Gnome;GTK;Text;Base64;JSON;YAML;Count;SHA1;SHA256;SHA384;SHA512;MD5;Checksum;Escape;Encode;HTML;URL;Prettify;Filter;Reverse;Trim;
+
 [Desktop Action new-window]
 Name=New Window
 Exec=textpieces


### PR DESCRIPTION
The idea behind this change is to make it easier to discover this application to launch. If I for example want to encode a string with Base64 I can then easily search for base or base64.