### PR TITLE
Fix preferences action-name in shortcuts window

### DIFF
--- a/resources/ui/ShortcutsWindow.blp
+++ b/resources/ui/ShortcutsWindow.blp
@@ -18,7 +18,7 @@ ShortcutsWindow help_overlay {
 
       ShortcutsShortcut {
         title: _("Preferences");
-        action-name: "win.preferences";
+        action-name: "win.open-preferences";
       }
 
       ShortcutsShortcut {


### PR DESCRIPTION
The shortcut was previously missing from the shortcuts window, due to the wrong action-name.