### PR TITLE
Fix translated strings seems untranslated

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -122,8 +122,10 @@ namespace TextPieces {
             instance = this;
 
             /* Initialize localization */
+            Intl.setlocale (LocaleCategory.ALL, "");
             Intl.bindtextdomain (Config.GETTEXT_PACKAGE, Config.GNOMELOCALEDIR);
             Intl.bind_textdomain_codeset (Config.GETTEXT_PACKAGE, "UTF-8");
+            Intl.textdomain (Config.GETTEXT_PACKAGE);
 
             /* Setup style scheme */
             Gtk.StyleContext.add_provider_for_display (


### PR DESCRIPTION
Copied from GNOME Calculator: https://gitlab.gnome.org/GNOME/gnome-calculator/-/blob/master/src/gnome-calculator.vala#L367-370