### PR TITLE
Help overlay improvements

### DIFF
--- a/resources/ui/SearchBar.blp
+++ b/resources/ui/SearchBar.blp
@@ -37,7 +37,7 @@ template TextPiecesSearchBar : Adw.Bin {
 
         Button {
           icon-name: "go-up-symbolic";
-          tooltip-text: _("Move to revious match");
+          tooltip-text: _("Move to previous match");
           action-name: "search.prev-match";
         }
 

--- a/resources/ui/ShortcutsWindow.blp
+++ b/resources/ui/ShortcutsWindow.blp
@@ -7,9 +7,15 @@ using Gtk 4.0;
 ShortcutsWindow help_overlay {
   ShortcutsSection {
     section-name: "shortcuts";
+    max-height: 12;
 
     ShortcutsGroup {
       title: _("General");
+
+      ShortcutsShortcut {
+        title: _("New window");
+        action-name: "app.new-window";
+      }
 
       ShortcutsShortcut {
         title: _("Keyboard shortcuts");
@@ -22,8 +28,13 @@ ShortcutsWindow help_overlay {
       }
 
       ShortcutsShortcut {
-        title: _("Quit");
+        title: _("Close window");
         action-name: "window.close";
+      }
+
+      ShortcutsShortcut {
+        title: _("Quit");
+        action-name: "app.quit";
       }
     }
 
@@ -73,5 +84,30 @@ ShortcutsWindow help_overlay {
         action-name: "win.save-as";
       }
     }
+
+    ShortcutsGroup {
+      title: _("Search and Replace");
+
+      ShortcutsShortcut {
+        title: _("Search");
+        accelerator: "<ctrl>f";
+      }
+
+      ShortcutsShortcut {
+        title: _("Replace");
+        accelerator: "<ctrl>h";
+      }
+
+      ShortcutsShortcut {
+        title: _("Move to previous match");
+        accelerator: "<Shift>Return";
+      }
+
+      ShortcutsShortcut {
+        title: _("Move to next match");
+        accelerator: "Return";
+      }
+    }
+
   }
 }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -57,7 +57,6 @@ namespace TextPieces {
             { "win.apply"             , "<Ctrl>Return"   },
             { "win.copy"              , "<Ctrl><Shift>c" },
             { "win.open-preferences"  , "<Ctrl>comma"    },
-            { "win.show-help-overlay" , "<Ctrl>question" },
             { "win.load-file"         , "<Ctrl>o"        },
             { "win.save-as"           , "<Ctrl>s"        },
             { "win.toggle-search"     , "<Alt>s"         },


### PR DESCRIPTION
**help-overlay: Update shortcuts**

Correct window.close title as Close window

Add several missing shortcuts
- Ctrl+N: New window
- Ctrl+Q: Quit

Add search and replace related shortcuts
- Ctrl+F: Search
- Ctrl+H: Replace
- Shift+Return: Move to previous match
- Return: Move to next match

**application: Remove redundant shortcut**
- Due to win.show-help-overlay shortcut already defined in GTK, we don't need to add this shortcut again.

**Fix a typo**
- revious -> previous
