### PR TITLE
fix: Fixed typo in tool description

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -141,7 +141,7 @@
     },
     {
       "name": "Reverse Lines",
-      "description": "Reoder lines in reverse order",
+      "description": "Reorder lines in reverse order",
       "icon": "object-flip-vertical-symbolic",
       "script": "reverse-lines"
     },

--- a/po/es.po
+++ b/po/es.po
@@ -910,7 +910,7 @@ msgstr "Quitar los espacios en blanco al final y los saltos de línea"
 
 #: data/tools.json
 msgctxt "tools"
-msgid "Reoder lines in reverse order"
+msgid "Reorder lines in reverse order"
 msgstr "Reordenar las líneas en orden inverso"
 
 #: data/tools.json

--- a/po/nl.po
+++ b/po/nl.po
@@ -913,7 +913,7 @@ msgstr "Verwijder witruimtes en nieuwe regels"
 
 #: data/tools.json
 msgctxt "tools"
-msgid "Reoder lines in reverse order"
+msgid "Reorder lines in reverse order"
 msgstr "Plaats alle regels in omgekeerde volgorde"
 
 #: data/tools.json

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -908,7 +908,7 @@ msgstr "Remova espaços e linhas à direita"
 
 #: data/tools.json
 msgctxt "tools"
-msgid "Reoder lines in reverse order"
+msgid "Reorder lines in reverse order"
 msgstr ""
 
 #: data/tools.json

--- a/po/textpieces.pot
+++ b/po/textpieces.pot
@@ -908,7 +908,7 @@ msgstr ""
 
 #: data/tools.json
 msgctxt "tools"
-msgid "Reoder lines in reverse order"
+msgid "Reorder lines in reverse order"
 msgstr ""
 
 #: data/tools.json

--- a/po/tools.pot
+++ b/po/tools.pot
@@ -236,7 +236,7 @@ msgstr ""
 
 #: data/tools.json
 msgctxt "tools"
-msgid "Reoder lines in reverse order"
+msgid "Reorder lines in reverse order"
 msgstr ""
 
 #: data/tools.json


### PR DESCRIPTION
Fixed a small typo in the description of the 'reverse lines' tool where 'reorder' was misspelled as 'reoder'