### PR TITLE
Add tools: hexadecimal to decimal and vice-versa

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -242,6 +242,18 @@
       "description": "Parse XML and prettify it",
       "icon": "format-justify-left-symbolic",
       "script": "format-xml"
+    },
+    {
+      "name": "Decimal to Hexadecimal",
+      "description": "Convert decimal numbers to hexadecimal",
+      "icon": "accessories-calculator-symbolic",
+      "script": "decimal-to-hexadecimal"
+    },
+    {
+      "name": "Hexadecimal to Decimal",
+      "description": "Convert hexadecimal numbers to decimal",
+      "icon": "accessories-calculator-symbolic",
+      "script": "hexadecimal-to-decimal"
     }
   ]
 }

--- a/scripts/decimal-to-hexadecimal
+++ b/scripts/decimal-to-hexadecimal
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2023 ZtereoHYPE <me@ztereohype.dev>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from sys import stdin, stdout
+
+for line in stdin:
+    words = line.split()
+    converted_words = [hex(int(word)) if word.isdigit() else word for word in words]
+    stdout.write(' '.join(converted_words) + '\n')

--- a/scripts/hexadecimal-to-decimal
+++ b/scripts/hexadecimal-to-decimal
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2023 ZtereoHYPE <me@ztereohype.dev>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from sys import stdin, stdout
+
+def is_hex(string):
+    hex_digits = frozenset('0123456789abcdefABCDEF')
+    return all(char in hex_digits for char in string)
+
+for line in stdin:
+    words = line.split()
+    stripped_words = [word[2:] if word.startswith('0x') and is_hex(word[2:]) else word for word in words]
+    converted_words = [str(int(word, 16)) if is_hex(word) else word for word in stripped_words]
+    stdout.write(' '.join(converted_words) + '\n')


### PR DESCRIPTION
This mimics Boop's hex to dec and vice-versa conversion, maintaining other strings, newlines, and spaces.

## Example IO:

### Hexadecimal to decimal
Input:
```
0x123 123 
0xABC abc
0x456555 hello

0x123zz
```
Output:
```
291 291
2748 2748
4547925 hello

0x123zz
```

### Decimal to hexadecimal
Input:
```
291 291
2748 2748
4547925 hello

0x123zz
```
Output:
```
0x123 0x123
0xabc 0xabc
0x456555 hello

0x123zz
```