### PR TITLE
Fix build error with blueprint-compiler 0.10.0

### DIFF
--- a/resources/ui/Editor.blp
+++ b/resources/ui/Editor.blp
@@ -42,7 +42,7 @@ template TextPiecesEditor : Adw.Bin {
           hexpand: false;
           width-request: 300;
           margin-top: 5;
-          margin-bottom: 2.5;
+          margin-bottom: 3;
           margin-start: 5;
           margin-end: 10;
           spacing: 3;

--- a/resources/ui/SearchBar.blp
+++ b/resources/ui/SearchBar.blp
@@ -15,7 +15,7 @@ template TextPiecesSearchBar : Adw.Bin {
       ]
 
       margin-top: 5;
-      margin-bottom: 2.5;
+      margin-bottom: 3;
       margin-start: 5;
       margin-end: 10;
       row-spacing: 6;


### PR DESCRIPTION
Fixes #130.

This PR changes the bottom margin in two files to the nearest integer, apparently Blueprint is no longer accepting floating values for margins?
Can't find anything here https://gitlab.gnome.org/jwestman/blueprint-compiler/-/releases.