### PR TITLE
appdata: Use appstreamcli for appdata validation

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -26,9 +26,9 @@ appstream_file = i18n.merge_file(
   install_dir: join_paths(get_option('datadir'), 'appdata')
 )
 
-appstream_util = find_program('appstream-util', required: false)
-if appstream_util.found()
-  test('Validate appstream file', appstream_util,
+appstreamcli = find_program('appstreamcli', required: false)
+if appstreamcli.found()
+  test('Validate appstream file', appstreamcli,
     args: ['validate', appstream_file]
   )
 endif


### PR DESCRIPTION
appstream-util is obsoleted by appstreamcli.