### PR TITLE
appdata: Add missing the `launchable` tag

### DIFF
--- a/data/com.github.liferooter.textpieces.appdata.xml.in
+++ b/data/com.github.liferooter.textpieces.appdata.xml.in
@@ -29,6 +29,7 @@ SPDX-License-Identifier: CC0-1.0
   <provides>
     <binary>textpieces</binary>
   </provides>
+  <launchable type="desktop-id">com.github.liferooter.textpieces.desktop</launchable>
   <developer_name>Gleb Smirnov</developer_name>
   <url type="homepage">https://github.com/liferooter/textpieces</url>
   <url type="bugtracker">https://github.com/liferooter/textpieces/issues</url>


### PR DESCRIPTION
This tag is optional but in use most of GNOME apps.

"This optional tag indicates possible methods to launch the software described in this component"

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-launchable